### PR TITLE
Add https:// to fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [Classic Matrix code](https://rezmason.github.io/matrix)
 - [3D mode](https://rezmason.github.io/matrix?version=3d)
 - [Holographic version](https://rezmason.github.io/matrix?version=holoplay) (requires a Looking Glass display; see it in action [here](https://www.youtube.com/watch?v=gwA9hfq1Ing))
-- Mirror mode, [with camera](https://rezmason.github.io/matrix/?version=updated&effect=mirror&camera=true) and [without](rezmason.github.io/matrix/?version=updated&effect=mirror). (Click to make ripples.)
+- Mirror mode, [with camera](https://rezmason.github.io/matrix/?version=updated&effect=mirror&camera=true) and [without](https://rezmason.github.io/matrix/?version=updated&effect=mirror). (Click to make ripples.)
 - [Matrix Resurrections updated code](https://rezmason.github.io/matrix?version=resurrections)
 - [Trinity mode](https://rezmason.github.io/matrix?version=trinity)
 - [Operator Matrix code (with ripple effects)](https://rezmason.github.io/matrix?version=operator)


### PR DESCRIPTION
This fixes the link to camera-less "mirror mode" with ripples when mouse-clicking

Apparently, #16 did the same thing with another link on the same line.