### PR TITLE
Fullscreen when added as "Bookmark" to iOS Homescreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,16 @@
 	<head>
 		<title>Matrix digital rain</title>
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0" />
+		<meta name="apple-mobile-web-app-capable" content="yes"></meta>
+      		<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent"></meta>
+		<meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0, viewport-fit=cover" />
 		<style>
+			@supports (padding-top: env(safe-area-inset-top)) {
+				body {
+					padding: 0;
+				   	height: calc(100% + env(safe-area-inset-top));
+			  	}
+		  	}
 			body {
 				background: black;
 				overflow: hidden;


### PR DESCRIPTION
I could not tolerate the iOS status bar on top of this beautiful simulation. That's why.

Idea: https://itnext.io/make-your-pwas-look-handsome-on-ios-fd8fdfcd5777

### before

![IMG_1CF91AB93414-1](https://user-images.githubusercontent.com/296476/192115937-b265d556-e9c3-4e67-89af-853918432df7.jpeg)

### after

![translucent](https://user-images.githubusercontent.com/296476/192115854-87bffaff-3cbf-4772-84b2-5ae62cab1e9a.png)
