### PR TITLE
Update stated bloom defaults in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Now you know link fu. Here's a list of customization options:
 - `density` - the number of 3D raindrops to draw, proportional to the default. Default is 1.0.
 - `forwardSpeed` - the rate that the 3D raindrops approach. Default is 1.0.
 - `slant` - the angle that the 2D raindrops fall, in degrees. Default is 0.
-- `bloomSize` - the glow quality, from 0 to 1. Default is 0.5. Lowering this value may help the digital rain run smoother on your device.
-- `bloomStrength` - the glow intensity, from 0 to 1. Default is 1.
+- `bloomSize` - the glow quality, from 0 to 1. Default is 0.4. Lowering this value may help the digital rain run smoother on your device.
+- `bloomStrength` - the glow intensity, from 0 to 1. Default is 0.7.
 - `ditherMagnitude` - the amount to randomly darken pixels, to conceal [banding](https://en.wikipedia.org/wiki/Colour_banding). Default is 0.05.
 - `resolution` - the image size, relative to the window size. Default is 1. Lowering this value may improve your performance, especially on high pixel density displays.
 - `raindropLength` - the vertical scale of "raindrops" in the columns. Can be any number.


### PR DESCRIPTION
Visual checks revealed that the default `bloomStrength` was not `1.0`, but something lower.

[Default config code in `config.js`](https://github.com/Rezmason/matrix/blob/44ce50b6d5ef34856bdbbeed41c315ca1d391f8e/js/config.js#L75) confirms it is `0.7`. I noticed the same issue for `bloomSize` while I was there.

Incredible work on this project, by the way!