### PR TITLE
Added flipY parameter to image texture RE issue #37

### DIFF
--- a/js/regl/utils.js
+++ b/js/regl/utils.js
@@ -59,6 +59,7 @@ const loadImage = (regl, url) => {
 					data,
 					mag: "linear",
 					min: "linear",
+					flipY: true,
 				});
 			}
 		})(),


### PR DESCRIPTION
I do not know if this issue also affects WebGPU, but just flipping the image texture with the flipY constructor parameter fixed the issue for me when viewing with WebGL.